### PR TITLE
Add control radiation DOM01 output

### DIFF
--- a/archived_cids.json
+++ b/archived_cids.json
@@ -20,4 +20,10 @@
                 "preffs": "./preffs/EUREC4A_ICON-LES_highCCN_DOM01_3D_native.preffs",
                 "tape_archive_prefix": "/arch/mh0010/m300408/experiments/EUREC4A/highCCN/output/DOM01/3D/"
         },
+	"bafybeiaepgfea7nohq5p3rpqzozzazgjee4y5pthgivq46gqwefjdo6zmq":{
+		"filename": "EUREC4A_ICON-LES_control_DOM01_radiation_native.zarr",
+                "preffs": "./preffs/EUREC4A_ICON-LES_control_DOM01_radiation_native.preffs",
+                "tape_archive_prefix": "/arch/mh0010/m300408/experiments/EUREC4A/control/output/DOM01/radiation/",
+		"comment": "During creation of cars, filename has been EUREC4A_ICON-LES_Control_DOM01_radiation_native.zarr.zstd; bafybeiaepgfea7nohq5p3rpqzozzazgjee4y5pthgivq46gqwefjdo6zmq points to incomplete zarr (all variables missed the last about 100 timesteps, except for time itself. Missing data has been added in additionional cars with numbers 651 - 662. Preffs file includes whole dataset including added cars.)"
+	},
 }

--- a/archived_cids.json
+++ b/archived_cids.json
@@ -22,8 +22,8 @@
         },
 	"bafybeiaepgfea7nohq5p3rpqzozzazgjee4y5pthgivq46gqwefjdo6zmq":{
 		"filename": "EUREC4A_ICON-LES_control_DOM01_radiation_native.zarr",
-                "preffs": "./preffs/EUREC4A_ICON-LES_control_DOM01_radiation_native.preffs",
+                "preffs": "zip://preffs/EUREC4A_ICON-LES_control_DOM01_radiation_native.preffs::https://zenodo.org/api/files/477b6b75-4a71-4c6b-8708-0056acd70fcf/preffs.zip",
                 "tape_archive_prefix": "/arch/mh0010/m300408/experiments/EUREC4A/control/output/DOM01/radiation/",
 		"comment": "During creation of cars, filename has been EUREC4A_ICON-LES_Control_DOM01_radiation_native.zarr.zstd; bafybeiaepgfea7nohq5p3rpqzozzazgjee4y5pthgivq46gqwefjdo6zmq points to incomplete zarr (all variables missed the last about 100 timesteps, except for time itself. Missing data has been added in additionional cars with numbers 651 - 662. Preffs file includes whole dataset including added cars.)"
-	},
+	}
 }


### PR DESCRIPTION
This dataset is about 20TB (> 500 `car`s). The resulting reference file is therefore too large to be committed to git.
I host the reference and index now on [zenodo](https://doi.org/10.5281/zenodo.7017189) to preserve them and make them available.

At some point these files should be maybe also/better hosted on the IPFS network to make it easier to extend the file collection.

For now the reference files can be opened with:
```python
import fsspec
import json
import pandas as pd

with open("archived_cids.json","rb") as f:
    r=json.load(f)
m = fsspec.open(r["bafybeiaepgfea7nohq5p3rpqzozzazgjee4y5pthgivq46gqwefjdo6zmq"]["preffs"], "rb")
with m as f:
    df=pd.read_parquet(f)
```